### PR TITLE
Fix loading sequence

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -11,5 +11,9 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="JasonAlvis_Core" setup_version="0.0.1" />
+    <module name="JasonAlvis_Core" setup_version="0.0.1">
+        <sequence>
+            <module name="Magento_Store"/>
+        </sequence>
+    </module>
 </config>


### PR DESCRIPTION
Magento loads modules in sequences. Without correct declaration your module is loaded at first which causes several issues (mine is in build phase without db/cache instance).
Adding the sequence declaration fixes the issue.